### PR TITLE
clean up and fix type stability

### DIFF
--- a/src/FluidProperties.jl
+++ b/src/FluidProperties.jl
@@ -6,6 +6,8 @@ end
 
 using Unitful, UnitfulMoles
 
+using Unitful: ustrip, uconvert
+
 export vapour_pressure, wet_air, dry_air, get_pressure, get_λ_evap
 
 include("fluid_properties.jl")


### PR DESCRIPTION
I had to clean up a little to understand things better.

But the actual improvement here is mostly just making sure to always use e.g. 1.0 instead of 1. If there is a branch where one returns an integer quantity and the other returns a float quantity things will be slow.