### PR TITLE
remove PhysicalConstants.jl. its too slow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["m.kearney@unimelb.edu.au", "rafaelschouten@gmail.com"]
 version = "0.1.0"
 
 [deps]
-PhysicalConstants = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulMoles = "999f2bd7-36bf-5ba7-9bc1-c9473aa75374"
 
@@ -12,7 +11,6 @@ UnitfulMoles = "999f2bd7-36bf-5ba7-9bc1-c9473aa75374"
 Aqua = "0.8"
 CSV = "0.10.15"
 DataFrames = "1.8.0"
-PhysicalConstants = "0.2.4"
 SafeTestsets = "0.1.0"
 Test = "1"
 Unitful = "1.24.0"

--- a/src/FluidProperties.jl
+++ b/src/FluidProperties.jl
@@ -2,9 +2,12 @@ module FluidProperties
 
 using Unitful, UnitfulMoles
 
-using PhysicalConstants.CODATA2022: g_n, σ, atm, R
-
 using Unitful: ustrip, uconvert
+
+# Define here instead of using PhysicalConstants.jl
+# Its too slow due to BigFloat conversions and allocation
+using Unitful: σ, atm, R
+const g_n = 9.80665u"m*s^-2"
 
 export atmospheric_pressure, dry_air_properties, enthalpy_of_vaporisation
 export vapour_pressure, water_properties, wet_air_properties


### PR DESCRIPTION
PhysicalConstants.jl seems to promote some values to `BigFloat`, which allocates memory and is painfully slow.

Just not worth having. So instead we use Unitful.jl constants, and define others ourselves.