### PR TITLE
improve lookup table syntax, add tests for it

### DIFF
--- a/src/FluidProperties.jl
+++ b/src/FluidProperties.jl
@@ -13,7 +13,7 @@ const atm = uconvert(u"Pa", 1Unitful.atm)
 export atmospheric_pressure, dry_air_properties, enthalpy_of_vaporisation, molar_enthalpy_of_vaporisation
 export vapour_pressure, water_properties, wet_air_properties
 export GasFractions, DryAirProperties, WetAirProperties, WaterProperties
-export VapourPressureEquation, GoffGratch, Teten, Huang, VPLookupTable
+export VapourPressureEquation, GoffGratch, Teten, Huang, VapourPressureLookup
 
 @compound H2O
 @compound O2

--- a/src/vapour_pressure.jl
+++ b/src/vapour_pressure.jl
@@ -64,19 +64,19 @@ High accuracy from -100 to 100 °C and reasonable performance.
 struct Huang <: VapourPressureEquation end
 
 vapour_pressure(::Huang, ::Missing) = missing
-function vapour_pressure(::Huang, Tk)
-    t = ustrip(u"°C", Tk)
-    if t > 0.0
+function vapour_pressure(::Huang, T)
+    Tc = ustrip(u"°C", T)
+    if Tc > 0.0
         # Huang (2018), water over liquid surface
-        return exp((34.494 - 4924.99 / (t + 237.1))) / ((t + 105.0)^1.57) * 1u"Pa"
+        return exp((34.494 - 4924.99 / (Tc + 237.1))) / ((Tc + 105.0)^1.57) * 1u"Pa"
     else
         # Huang (2018), water over ice surface
-        return exp((43.494 - 6545.8 / (t + 278.0))) / ((t + 868.0)^2) * 1u"Pa"
+        return exp((43.494 - 6545.8 / (Tc + 278.0))) / ((Tc + 868.0)^2) * 1u"Pa"
     end
 end
 
 """
-    VPLookupTable <: VapourPressureEquation
+    VapourPressureLookup <: VapourPressureEquation
 
 Lookup-table with linear interpolation for [`vapour_pressure`](@ref).
 
@@ -93,30 +93,29 @@ for repeated calls.
 
 # Example
 ```julia
-lut = VPLookupTable()
-lut = VPLookupTable(Tmin=-80.0, Tmax=100.0, dT=0.05, formulation=Huang())
-es  = vapour_pressure(lut, 293.15u"K")
+vpl = VapourPressureLookup()
+vpl = VapourPressureLookup(tmin=-80.0u"°C", tmax=100.0u"°C", step=0.05u"K", formulation=Huang())
+es  = vapour_pressure(vpl, 293.15u"K")
 ```
 """
-struct VPLookupTable <: VapourPressureEquation
-    Tmin_C::Float64
-    dT::Float64
-    es_table::Vector{Float64}  # Pa, raw values (unit attached on return)
+struct VapourPressureLookup<: VapourPressureEquation
+    tmin::typeof(1.0u"K")
+    step::typeof(1.0u"K")
+    lookup::Vector{typeof(1.0u"Pa")}
+end
+function VapourPressureLookup(formulation=GoffGratch(); tmin=-40.0u"°C", tmax=90.0u"°C", step=0.1u"K")
+    unit(step) == u"K" || throw(ArgumentError("step must be given in Kelvin (K), got $(unit(step))"))
+    ts = tmin:step:tmax
+    table = [vapour_pressure(formulation, t) for t in ts]
+    return VapourPressureLookup(tmin, step, table)
 end
 
-function VPLookupTable(; Tmin=-40.0, Tmax=90.0, dT=0.1, formulation=GoffGratch())
-    Ts = Tmin:dT:Tmax
-    es_table = [ustrip(u"Pa", vapour_pressure(formulation, (T + 273.15)u"K")) for T in Ts]
-    return VPLookupTable(float(Tmin), float(dT), es_table)
-end
-
-vapour_pressure(::VPLookupTable, ::Missing) = missing
-function vapour_pressure(lut::VPLookupTable, T)
-    Tc = ustrip(u"°C", T)
-    x  = (Tc - lut.Tmin_C) / lut.dT         # fractional 0-based index
-    i  = clamp(Int(floor(x)) + 1, 1, length(lut.es_table) - 1)
-    w  = x - floor(x)                         # interpolation weight [0, 1)
-    return (lut.es_table[i] * (1 - w) + lut.es_table[i+1] * w) * 1u"Pa"
+vapour_pressure(::VapourPressureLookup, ::Missing) = missing
+function vapour_pressure(vpl::VapourPressureLookup, T)
+    x  = (T - vpl.tmin) / vpl.step         # fractional 0-based index (dimensionless)
+    i  = clamp(floor(Int, x) + 1, 1, length(vpl.lookup) - 1)
+    w  = x - floor(x)                      # interpolation weight [0, 1)
+    return vpl.lookup[i] * (1 - w) + vpl.lookup[i+1] * w
 end
 
 """
@@ -131,4 +130,4 @@ Calculates saturation vapour pressure (Pa) for a given air temperature.
 The `GoffGratch` formulation is used by default.
 """
 vapour_pressure(::Missing) = missing
-vapour_pressure(Tk) = vapour_pressure(GoffGratch(), Tk)
+vapour_pressure(T) = vapour_pressure(GoffGratch(), T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,3 +11,4 @@ end
 
 @safetestset "Test against NicheMapR outputs" begin include("nichemapr_tests.jl") end
 @safetestset "Huang (2018) reference values" begin include("huang_tests.jl") end
+@safetestset "VapourPressureLookup" begin include("vapour_pressure_lookup_tests.jl") end

--- a/test/vapour_pressure_lookup_tests.jl
+++ b/test/vapour_pressure_lookup_tests.jl
@@ -1,0 +1,78 @@
+using FluidProperties
+import FluidProperties: VapourPressureLookup, GoffGratch, Teten, Huang
+using Test
+using Unitful
+
+@testset "VapourPressureLookup" begin
+
+    @testset "construction" begin
+        # default construction succeeds
+        vpl = VapourPressureLookup()
+        @test vpl isa VapourPressureLookup
+
+        # custom range and step
+        vpl = VapourPressureLookup(; tmin=-80.0u"°C", tmax=100.0u"°C", step=0.05u"K")
+        @test vpl isa VapourPressureLookup
+
+        # alternative underlying formulations
+        @test VapourPressureLookup(Teten()) isa VapourPressureLookup
+        @test VapourPressureLookup(Huang()) isa VapourPressureLookup
+
+        # step must be in Kelvin
+        @test_throws ArgumentError VapourPressureLookup(step=0.1u"°C")
+    end
+
+    @testset "matches underlying formulation" begin
+        # A fine step should make the lookup nearly identical to the
+        # underlying equation at any in-range temperature.
+        for formulation in (GoffGratch(), Huang(), Teten())
+            vpl = VapourPressureLookup(formulation;
+                tmin=-40.0u"°C", tmax=80.0u"°C", step=0.01u"K",
+            )
+            for Tc in -30.0:5.0:70.0
+                T = (Tc + 273.15) * u"K"
+                @test vapour_pressure(vpl, T) ≈ vapour_pressure(formulation, T) rtol=1e-4
+            end
+        end
+    end
+
+    @testset "returns Pa" begin
+        vpl = VapourPressureLookup()
+        @test unit(vapour_pressure(vpl, 293.15u"K")) == u"Pa"
+    end
+
+    @testset "linear interpolation at midpoint" begin
+        # Halfway between two adjacent table nodes should equal the
+        # average of the underlying equation evaluated at those nodes.
+        formulation = GoffGratch()
+        vpl = VapourPressureLookup(formulation;
+            tmin=-10.0u"°C", tmax=40.0u"°C", step=1.0u"K",
+        )
+        # 290.15 K = 17°C and 291.15 K = 18°C land exactly on table nodes
+        T1 = 290.15u"K"
+        T2 = 291.15u"K"
+        Tmid = 290.65u"K"
+        es1 = vapour_pressure(formulation, T1)
+        es2 = vapour_pressure(formulation, T2)
+        @test vapour_pressure(vpl, Tmid) ≈ 0.5 * (es1 + es2) rtol=1e-10
+    end
+
+    @testset "exact at table endpoints" begin
+        # At the tabulated nodes the lookup should return the underlying
+        # equation exactly (no interpolation between adjacent cells).
+        formulation = GoffGratch()
+        vpl = VapourPressureLookup(formulation;
+            tmin=0.0u"°C", tmax=30.0u"°C", step=1.0u"K",
+        )
+        for Tc in 1.0:5.0:25.0
+            T = (Tc + 273.15) * u"K"
+            @test vapour_pressure(vpl, T) ≈ vapour_pressure(formulation, T) rtol=1e-12
+        end
+    end
+
+    @testset "missing input" begin
+        vpl = VapourPressureLookup()
+        @test ismissing(vapour_pressure(vpl, missing))
+    end
+
+end


### PR DESCRIPTION
Few improvements:
- there were a lot of abbreviataions, it was hard to read
- formulation can just be the first argument, no need for the keyword
- there were no tests

I standardised a bit of the other syntax too where it didn't match the package